### PR TITLE
Fix missing ThreadPool initialization

### DIFF
--- a/core/bridge_polling_loop.py
+++ b/core/bridge_polling_loop.py
@@ -67,6 +67,7 @@ class Tuya2MqttBridge:
 
         self._register_mqtt_handlers()
         self._shutdown_event = threading.Event()
+        self._daemon_thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=4)
 
         metrics_cfg = ext_cfg.get("metrics", {})
         if metrics_cfg.get("enabled", False):


### PR DESCRIPTION
## Summary
- initialize `_daemon_thread_pool` in `Tuya2MqttBridge.__init__`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68834e14ef5c83338a2da480115aa191