### PR TITLE
Fix import paths

### DIFF
--- a/core/utility_functions.py
+++ b/core/utility_functions.py
@@ -2,7 +2,7 @@ import functools
 import errno
 import socket
 from contextlib import closing
-from const import BridgeState
+from core.tuya.tuya_constants import BridgeState
 
 def require_state(*allowed):
     def deco(func):


### PR DESCRIPTION
## Summary
- correct import of `BridgeState`

## Testing
- `python -m compileall .`
- `python tuya2mqtt.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688350dc2aa88333942a6f297e4c6428