### PR TITLE
Fix metrics publishing

### DIFF
--- a/core/bridge_polling_loop.py
+++ b/core/bridge_polling_loop.py
@@ -31,6 +31,8 @@ from core.tuya.discovery.tuya_udp_device_scanner import Scanner
 class Tuya2MqttBridge:
     def __init__(self):
         self._logger = configure_logger()
+        # Identifier used in MQTT topics
+        self.service_id = const.SERVICE_ID
         self._config = load_settings("/home/tsmolyanin/wk/ttmp/tuya2mqtt/settings/config.toml")
         self._device_store = DeviceStore(self._logger)
         SignalManager(self._graceful_shutdown, self._logger).install()


### PR DESCRIPTION
## Summary
- add a `service_id` attribute to `Tuya2MqttBridge`
- metrics extension now uses the bridge's `service_id`

## Testing
- `python -m py_compile core/bridge_polling_loop.py extensions/metrics/metrics_collection_extension.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883650f64bc83339754435892cd1c53