### PR TITLE
Ensure new device configs propagate to Homie sync

### DIFF
--- a/core/bridge_polling_loop.py
+++ b/core/bridge_polling_loop.py
@@ -347,8 +347,12 @@ class Tuya2MqttBridge:
                 new_devices_conf = []
             self._device_store.write(const.DEVICES_CONF_FILE, joined_devices_config)
             self._device_store.load_devices(joined_devices_config)
+            self._device_store.make_hum_name_to_id()
             if self._sync:
-                self._sync.on_devices_added(new_devices_conf)
+                updated_new_devices = [
+                    self._device_store.get_devices(dev["id"]).to_dict() for dev in new_devices_conf
+                ]
+                self._sync.on_devices_added(updated_new_devices)
             if new_devices_conf:
                 response = [self._device_store.make_device_brief(dev) for dev in new_devices_conf]
             else:

--- a/core/device_repository.py
+++ b/core/device_repository.py
@@ -113,8 +113,9 @@ class DeviceStore:
             for device in joined_devs:
                 if device["id"] in devices_id_to_add:
                     filtered_joined_devs.append(device)
-            
+
             joined_devs = filtered_joined_devs
+            new_devices_conf = filtered_joined_devs
 
         return new_devices_conf, joined_devs
 


### PR DESCRIPTION
## Summary
- Populate new device configs when `devices.json` is missing
- Refresh name mapping and propagate updated new devices to Homie lifecycle

## Testing
- `python -m py_compile core/device_repository.py core/bridge_polling_loop.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891e565f65c833382e2d8ff2a9a3ae2