### PR TITLE
Fix unpacking for devices without templates

### DIFF
--- a/extensions/homie/common/tuya_to_homie_converter.py
+++ b/extensions/homie/common/tuya_to_homie_converter.py
@@ -242,7 +242,7 @@ class TuyaHomieConverter:
         tpl = self.template_manager.find_template(device)
         if tpl:
             return self._apply_template(device, tpl)
-        dev_id, desc = self.generic_converter.device_to_homie(device)
+        dev_id, desc, _ = self.generic_converter.device_to_homie(device)
         return dev_id, desc, None, False
 
     def convert_devices(self, devices: List[Dict[str, Any]]) -> Dict[str, Tuple[Dict[str, Any], Dict[str, str]]]:

--- a/tests/test_converter_without_template.py
+++ b/tests/test_converter_without_template.py
@@ -1,0 +1,27 @@
+"""Tests for TuyaHomieConverter handling of devices without templates."""
+
+from extensions.homie.common.tuya_to_homie_converter import (
+    TemplateManager,
+    TuyaHomieConverter,
+)
+
+
+def test_convert_device_without_template():
+    converter = TuyaHomieConverter(
+        TemplateManager("extensions/homie/common/templates/")
+    )
+
+    device = {
+        "id": "dummy123",
+        "name": "Dummy",
+        "mapping": {
+            "1": {"code": "switch", "type": "Boolean"}
+        },
+    }
+
+    dev_id, desc, mapping, strict = converter.convert_device(device)
+
+    assert dev_id == "dummy123"
+    assert mapping is None
+    assert strict is False
+    assert desc["name"] == "Dummy"


### PR DESCRIPTION
## Summary
- handle extra return value from GenericConverter
- add regression test for devices without templates

## Testing
- `PYTHONPATH=. python3 tests/test_converter_without_template.py`

------
https://chatgpt.com/codex/tasks/task_e_689b38735d0883339cd83bcb729041b9